### PR TITLE
:hammer: Deeplicate v2.0

### DIFF
--- a/Assets/OhanaYa/Deeplicate/Editor/Deeplicator.cs
+++ b/Assets/OhanaYa/Deeplicate/Editor/Deeplicator.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEditor;
 
-using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 


### PR DESCRIPTION
- #4
- フォルダコピー以外にも対応
- サブアセットの取り扱いを修正 #3 
    - 同名サブアセットの取り扱いは一部未対応 #6
        - プレハブ内の `GameObject` や `Component` ならどうにかなるが、一般アセットは簡単に確認する方法がなさそう :thinking: 
            - `Component` も順番が公開されていないので `GetComponents` で返ってくる結果に頼っている :see_no_evil: 

## 再マッピング時の挙動の変更

境遇が最も近いアセットを参照するように再マッピングを行う。

以下のようなフォルダ構成を例とする（ `D` は `E` を参照している）

```
Assets
└─A
  ├─B
  │  └─D
  └─C
    └─E
```

### `A` をコピーした場合

```
Assets
├─A
│  ├─B
│  │  └─D
│  └─C
│    └─E
└─A'
  ├─B
  │  └─D
  └─C
    └─E
```

`A'/B/D` は `A'/C/E` を参照するように再マッピングされる。

### `A/B/D` `A/C/E` をコピーした場合

```
Assets
└─A
  ├─B
  │  ├─D
  │  └─D'
  └─C
    ├─E
    └─E'
```

`A/B/D'` は `A/C/E'` を参照するように再マッピングされる。

### `A/B` `A/C` をコピーした場合

```
Assets
└─A
  ├─B
  │  └─D
  ├─B'
  │  └─D
  ├─C
  │  └─E
  └─C'
    └─E
```

`A/B'/D` は `A/C'/E` を参照するように再マッピングされる。

### `A/B` `A/C` `A/C/E` をコピーした場合

```
Assets
└─A
  ├─B
  │  └─D
  ├─B'
  │  └─D
  ├─C
  │  ├─E
  │  └─E'
  └─C'
    └─E
```

`A/B'/D` は同じくフォルダごとコピーされた `A/C'/E` を参照するように再マッピングされる。

### `A/B` `A/C/E` をコピーした場合

```
Assets
└─A
  ├─B
  │  └─D
  ├─B'
  │  └─D
  └─C
    ├─E
    └─E'
```

`A/B'/D` は同じタイミングでコピーされた `A/C/E'` を参照するように再マッピングされる。