### PR TITLE
v3.0.1

### DIFF
--- a/Assets/OhanaYa/Deeplicate/package.json
+++ b/Assets/OhanaYa/Deeplicate/package.json
@@ -2,7 +2,7 @@
     "name": "dev.ohanaya.deeplicate",
     "displayName": "Deeplicate",
     "version": "3.0.0",
-    "unity": "5.4",
+    "unity": "2019.4",
     "description": "Deep copying assets.",
     "keywords": ["duplicate", "copy", "deepcopy", "deeplicate"],
     "license": "MIT",


### PR DESCRIPTION
`package.json` の `unity` 要素はPackageManager実装以降のバージョンしか指定できないみたいなので、 `path` クエリパラメータが確実に使えそうなバージョンを指定しておく :sob: 